### PR TITLE
Fixed bug - 2 argument must be array

### DIFF
--- a/Flame/Rest/DI/RestExtension.php
+++ b/Flame/Rest/DI/RestExtension.php
@@ -54,7 +54,7 @@ class RestExtension extends CompilerExtension
 			->setClass($config['time']['validator'])
 			->setArguments(array($config['time']['format']));
 
-		$resourceValidator->addSetup('addValidator', $dateTimeValidator);
+		$resourceValidator->addSetup('addValidator', array($dateTimeValidator));
 
 		$container->addDefinition($this->prefix('resourceFactory'))
 			->setClass('Flame\Rest\ResourceFactory');


### PR DESCRIPTION
Fix for: 
**Argument 2 passed to Nette\DI\ServiceDefinition::addSetup() must be of the type array, object given, called in /home/budry/www/...../vendor/flame/tiny-rest/Flame/Rest/DI/RestExtension.php on line 57 and defined**
