### PR TITLE
Fixed wrong header for content type detection

### DIFF
--- a/Flame/Rest/Application/Routers/RestRoute.php
+++ b/Flame/Rest/Application/Routers/RestRoute.php
@@ -271,7 +271,7 @@ class RestRoute implements IRouter
 			return $format;
 		}
 
-		$header = $request->getHeader('Accept'); // http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html
+		$header = $request->getHeader('Content-Type');
 		foreach ($this->formats as $format => $fullFormatName) {
 			$fullFormatName = Strings::replace($fullFormatName, '/\//', '\/');
 			if (Strings::match($header, "/{$fullFormatName}/")) {


### PR DESCRIPTION
Because `Accept` header is for allowed response format (you can see at your linked [page] (http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html)). Request format is in `Content-Type` header